### PR TITLE
Migrate to cats-effect 3, update all dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val Version           = "0.0.3"
 lazy val ScalaVersion      = "2.13.10"
 lazy val CatsEffectVersion = "3.4.6"
 lazy val OdinVersion       = "0.13.0"
-lazy val ScalaTestVersion  = "3.2.0"
+lazy val ScalaTestVersion  = "3.2.15"
 lazy val RocksDbVersion    = "6.6.4"
 
 lazy val CatsEffect = "org.typelevel" %% "cats-effect" % CatsEffectVersion

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,11 @@
 lazy val Version           = "0.0.3"
 lazy val ScalaVersion      = "2.13.10"
-lazy val CatsEffectVersion = "2.3.0"
-lazy val OdinVersion       = "0.9.1"
+lazy val CatsEffectVersion = "3.4.6"
+lazy val OdinVersion       = "0.13.0"
 lazy val ScalaTestVersion  = "3.2.0"
 lazy val RocksDbVersion    = "6.6.4"
+
+lazy val CatsEffect = "org.typelevel" %% "cats-effect" % CatsEffectVersion
 
 val GlobalSettingsGroup: Seq[Setting[_]] = Seq(
   version := Version,
@@ -30,7 +32,7 @@ lazy val effect = (project in file("raft4s-effect"))
   .settings(
     name := "raft4s-effect",
     libraryDependencies ++= Seq(
-      "org.typelevel"        %% "cats-effect" % CatsEffectVersion,
+      CatsEffect,
       "com.github.valskalla" %% "odin-core"   % OdinVersion,
       "org.scalatest"        %% "scalatest"   % ScalaTestVersion % Test
     )
@@ -57,6 +59,7 @@ lazy val grpc = (project in file("raft4s-grpc"))
       scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
     ),
     libraryDependencies ++= Seq(
+      CatsEffect,
       "com.thesamet.scalapb" %% "scalapb-runtime"      % scalapb.compiler.Version.scalapbVersion % "protobuf",
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
       "io.grpc"               % "grpc-netty"           % scalapb.compiler.Version.grpcJavaVersion,
@@ -71,6 +74,7 @@ lazy val rocksdb = (project in file("raft4s-rocksdb"))
   .settings(
     name := "raft4s-rocksdb",
     libraryDependencies ++= Seq(
+      CatsEffect,
       "org.rocksdb" % "rocksdbjni" % RocksDbVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,8 @@ lazy val grpc = (project in file("raft4s-grpc"))
   .settings(GlobalSettingsGroup)
   .settings(
     name := "raft4s-grpc",
-    PB.targets in Compile := Seq(
-      scalapb.gen() -> (sourceManaged in Compile).value / "scalapb"
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
     ),
     libraryDependencies ++= Seq(
       "com.thesamet.scalapb" %% "scalapb-runtime"      % scalapb.compiler.Version.scalapbVersion % "protobuf",

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val ScalaVersion      = "2.13.10"
 lazy val CatsEffectVersion = "3.4.6"
 lazy val OdinVersion       = "0.13.0"
 lazy val ScalaTestVersion  = "3.2.15"
-lazy val RocksDbVersion    = "6.6.4"
+lazy val RocksDbVersion    = "7.9.2"
 
 lazy val CatsEffect = "org.typelevel" %% "cats-effect" % CatsEffectVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val Version           = "0.0.3"
-lazy val ScalaVersion      = "2.13.4"
+lazy val ScalaVersion      = "2.13.10"
 lazy val CatsEffectVersion = "2.3.0"
 lazy val OdinVersion       = "0.9.1"
 lazy val ScalaTestVersion  = "3.2.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.8.2

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0-RC4")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.9"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.10"

--- a/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/LeaderAnnouncerImpl.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/LeaderAnnouncerImpl.scala
@@ -2,7 +2,7 @@ package raft4s.effect.internal.impl
 
 import cats.Monad
 import cats.effect.Concurrent
-import cats.effect.concurrent.{Deferred, Ref}
+import cats.effect.{Deferred, Ref}
 import cats.implicits._
 import raft4s.Node
 import raft4s.internal.{LeaderAnnouncer, Logger}

--- a/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/LogPropagatorImpl.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/LogPropagatorImpl.scala
@@ -1,7 +1,6 @@
 package raft4s.effect.internal.impl
 
-import cats.effect.Concurrent
-import cats.effect.concurrent.Ref
+import cats.effect.{Concurrent, Ref}
 import cats.implicits._
 import raft4s.Node
 import raft4s.internal.{LogPropagator, Logger}

--- a/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/MembershipManagerImpl.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/MembershipManagerImpl.scala
@@ -1,8 +1,7 @@
 package raft4s.effect.internal.impl
 
 import cats.Monad
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.{Ref, Sync}
 import cats.implicits._
 import raft4s.Node
 import raft4s.internal.MembershipManager

--- a/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/RpcClientProviderImpl.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/internal/impl/RpcClientProviderImpl.scala
@@ -1,7 +1,6 @@
 package raft4s.effect.internal.impl
 
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.{Ref, Sync}
 import cats.implicits._
 import cats.{Monad, MonadError}
 import raft4s.internal.{ErrorLogging, Logger, RpcClientProvider}

--- a/raft4s-effect/src/main/scala/raft4s/effect/storage/file/FileSnapshotStorage.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/storage/file/FileSnapshotStorage.scala
@@ -1,7 +1,6 @@
 package raft4s.effect.storage.file
 
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.{Ref, Sync}
 import cats.implicits._
 import raft4s.internal.{ErrorLogging, Logger}
 import raft4s.storage.Snapshot

--- a/raft4s-effect/src/main/scala/raft4s/effect/storage/memory/MemoryLogStorage.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/storage/memory/MemoryLogStorage.scala
@@ -1,7 +1,6 @@
 package raft4s.effect.storage.memory
 
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.{Ref, Sync}
 import cats.implicits._
 import raft4s.LogEntry
 import raft4s.storage.LogStorage

--- a/raft4s-effect/src/main/scala/raft4s/effect/storage/memory/MemorySnapshotStorage.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/storage/memory/MemorySnapshotStorage.scala
@@ -1,8 +1,7 @@
 package raft4s.effect.storage.memory
 
 import cats.Monad
-import cats.effect.Concurrent
-import cats.effect.concurrent.Ref
+import cats.effect.{Concurrent, Ref}
 import cats.implicits._
 import raft4s.storage.{Snapshot, SnapshotStorage}
 

--- a/raft4s-effect/src/main/scala/raft4s/effect/storage/memory/MemoryStorage.scala
+++ b/raft4s-effect/src/main/scala/raft4s/effect/storage/memory/MemoryStorage.scala
@@ -1,11 +1,11 @@
 package raft4s.effect.storage.memory
 
-import cats.effect.Concurrent
+import cats.effect.Async
 import cats.implicits._
 import raft4s.Storage
 
 object MemoryStorage {
-  def empty[F[_]: Concurrent]: F[Storage[F]] =
+  def empty[F[_]: Async]: F[Storage[F]] =
     for {
       snapshotStorage <- MemorySnapshotStorage.empty[F]
       stateStorage    <- MemoryStateStorage.empty[F]

--- a/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/GRPCClientBuilder.scala
+++ b/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/GRPCClientBuilder.scala
@@ -1,14 +1,14 @@
 package raft4s.effect.rpc.grpc.io
 
 import _root_.io.grpc.ManagedChannelBuilder
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import raft4s.Node
 import raft4s.effect.rpc.grpc.io.internal.GRPCRaftClient
 import raft4s.internal.Logger
 import raft4s.rpc.grpc.serializer.Serializer
 import raft4s.rpc.{RpcClient, RpcClientBuilder}
 
-class GRPCClientBuilder(implicit L: Logger[IO], CS: ContextShift[IO], S: Serializer) extends RpcClientBuilder[IO] {
+class GRPCClientBuilder(implicit L: Logger[IO], S: Serializer) extends RpcClientBuilder[IO] {
 
   override def build(node: Node): RpcClient[IO] = {
 

--- a/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/GRPCServerBuilder.scala
+++ b/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/GRPCServerBuilder.scala
@@ -2,6 +2,7 @@ package raft4s.effect.rpc.grpc.io
 
 import _root_.io.grpc.ServerBuilder
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import raft4s.{Node, Raft}
 import raft4s.effect.rpc.grpc.io.internal.GRPCRaftService
 import raft4s.grpc.protos
@@ -12,7 +13,7 @@ import raft4s.rpc.{RpcServer, RpcServerBuilder}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.blocking
 
-class GRPCServerBuilder(implicit S: Serializer, L: Logger[IO]) extends RpcServerBuilder[IO] {
+class GRPCServerBuilder(implicit S: Serializer, L: Logger[IO], R: IORuntime) extends RpcServerBuilder[IO] {
 
   override def build(node: Node, raft: Raft[IO]): IO[RpcServer[IO]] =
     IO.delay {

--- a/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/implicits.scala
+++ b/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/implicits.scala
@@ -1,11 +1,12 @@
 package raft4s.effect.rpc.grpc.io
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import raft4s.internal.Logger
 import raft4s.rpc.grpc.serializer.JavaSerializer
 
 object implicits {
-  implicit val serializer                                                  = new JavaSerializer
-  implicit def clientBuilder(implicit L: Logger[IO], CS: ContextShift[IO]) = new GRPCClientBuilder
-  implicit def serverBuilder(implicit L: Logger[IO], CS: ContextShift[IO]) = new GRPCServerBuilder
+  implicit val serializer                                          = new JavaSerializer
+  implicit def clientBuilder(implicit L: Logger[IO], R: IORuntime) = new GRPCClientBuilder
+  implicit def serverBuilder(implicit L: Logger[IO], R: IORuntime) = new GRPCServerBuilder
 }

--- a/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/internal/GRPCRaftClient.scala
+++ b/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/internal/GRPCRaftClient.scala
@@ -1,6 +1,6 @@
 package raft4s.effect.rpc.grpc.io.internal
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import com.google.protobuf
 import io.grpc.ManagedChannel
 import raft4s.grpc.protos
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.blocking
 
 private[grpc] class GRPCRaftClient(address: Node, channel: ManagedChannel, serializer: Serializer)(implicit
-  CS: ContextShift[IO],
   logger: Logger[IO]
 ) extends RpcClient[IO] {
 

--- a/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/internal/GRPCRaftService.scala
+++ b/raft4s-grpc/src/main/scala/raft4s/effect/rpc/grpc/io/internal/GRPCRaftService.scala
@@ -1,6 +1,7 @@
 package raft4s.effect.rpc.grpc.io.internal
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import raft4s.grpc.protos
 import raft4s.internal.Logger
 import raft4s.protocol._
@@ -11,7 +12,10 @@ import raft4s.{Command, LogEntry, Node, Raft}
 import java.nio.ByteBuffer
 import scala.concurrent.Future
 
-private[grpc] class GRPCRaftService(raft: Raft[IO], serializer: Serializer)(implicit val logger: Logger[IO])
+private[grpc] class GRPCRaftService(raft: Raft[IO], serializer: Serializer)(
+  implicit val logger: Logger[IO],
+  runtime: IORuntime,
+)
     extends protos.RaftGrpc.Raft {
 
   override def vote(request: protos.VoteRequest): Future[protos.VoteResponse] =

--- a/raft4s-rocksdb/src/main/scala/raft4s/effect/storage/rocksdb/RocksDBLogStorage.scala
+++ b/raft4s-rocksdb/src/main/scala/raft4s/effect/storage/rocksdb/RocksDBLogStorage.scala
@@ -108,7 +108,7 @@ object RocksDBLogStorage {
     } yield db
 
     for {
-      _  <- Resource.liftF(Try(jrocks.RocksDB.loadLibrary()).liftTo[F])
+      _  <- Resource.eval(Try(jrocks.RocksDB.loadLibrary()).liftTo[F])
       db <- Resource.make(acquire)(d => Sync[F].delay(d.close()))
 
     } yield new RocksDBLogStorage[F](db)


### PR DESCRIPTION
- Updates cats-effect to 3.4.6
- Updates odin to 0.13.0
- Updates rocksdb to 7.9.2
- Updates sbt to 1.8.2
- Updates sbt-protoc to 1.0.6
- Updates scala to 2.13.10
- Updates scalapb compiler plugin to 0.10.10
- Updates scalatest to 3.2.15

The cats-effect 3 migration required some source-level changes, mainly:

- Replacing instances of `Timer[F]` with `Temporal[F]`
- Replacing some `F[_]: Monad: Concurrent` constraints with `F[_]: Async`
- Removing `ContextShift` instances and requiring an `IORuntime` where necessary